### PR TITLE
Bump to latest version of qpdf package

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -8,8 +8,8 @@ echo "--------> Install qpdf"
 BUILD_DIR=$1
 VENDOR_DIR="vendor/qpdf"
 DOWNLOAD_BASE_PATH="http://us-west-2.clouds.archive.ubuntu.com/ubuntu/pool/main/q/qpdf"
-LIB_DPKG=libqpdf13_5.1.1-1_amd64.deb
-BIN_DPKG=qpdf_5.1.1-1_amd64.deb
+LIB_DPKG=libqpdf21_8.2.1-1_amd64.deb
+BIN_DPKG=qpdf_8.2.1-1_amd64.deb
 
 echo "Downloading binaries" | indent
 cd $BUILD_DIR


### PR DESCRIPTION
Here is output from Heroku...

```
$ heroku buildpacks
=== dcauto Buildpack URLs
1. https://github.com/gadgetonline/heroku-buildpack-qpdf.git
2. https://github.com/heroku/heroku-buildpack-activestorage-preview
3. heroku/ruby

$ heroku run 'qpdf --version' --remote heroku 
Running qpdf --version on ⬢ dcauto... up, run.9834 (Hobby)
qpdf version 8.2.1
Run qpdf --copyright to see copyright and license information.
```
